### PR TITLE
Reduce rpc usage

### DIFF
--- a/ecg-node-config.json
+++ b/ecg-node-config.json
@@ -18,7 +18,7 @@
             "enabled": false
         },
         "USER_SLASHER": {
-            "enabled": true,
+            "enabled": false,
             "minSizeToSlash": 20000
         },
         "AUCTION_BIDDER": {
@@ -27,7 +27,7 @@
             "minProfitUsdc": 20
         },
         "TESTNET_MARKET_MAKER": {
-            "enabled": true,
+            "enabled": false,
             "threshold": 0.005,
             "uniswapPairs": [
                 {

--- a/src/model/ProtocolData.ts
+++ b/src/model/ProtocolData.ts
@@ -1,0 +1,9 @@
+export interface ProtocolData {
+  creditMultiplier: bigint;
+}
+
+export interface ProtocolDataFileStructure {
+  updated: number;
+  updatedHuman: string;
+  data: ProtocolData;
+}

--- a/src/processors/AuctionBidder.ts
+++ b/src/processors/AuctionBidder.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { Auction, AuctionStatus, AuctionsFileStructure } from '../model/Auction';
 import { DATA_DIR } from '../utils/Constants';
-import { GetNodeConfig, ReadJSON, sleep } from '../utils/Utils';
+import { GetNodeConfig, GetProtocolData, ReadJSON, sleep } from '../utils/Utils';
 import path from 'path';
 import {
   AuctionHouse__factory,
@@ -43,8 +43,7 @@ async function AuctionBidder() {
     }
 
     const web3Provider = new ethers.JsonRpcProvider(rpcURL);
-    const profitManagerContract = ProfitManager__factory.connect(GetProfitManagerAddress(), web3Provider);
-    const creditMultiplier = await profitManagerContract.creditMultiplier();
+    const creditMultiplier = GetProtocolData().creditMultiplier;
 
     const auctionsToCheck = auctionFileData.auctions.filter((_) => _.status == AuctionStatus.ACTIVE);
     console.log(`AuctionBidder: Will check ${auctionsToCheck.length} auctions`);

--- a/src/processors/LoanCaller.ts
+++ b/src/processors/LoanCaller.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { ReadJSON, WaitUntilScheduled, sleep } from '../utils/Utils';
 import path from 'path';
 import { DATA_DIR } from '../utils/Constants';
@@ -33,6 +33,7 @@ async function LoanCaller() {
       await WaitUntilScheduled(startDate, RUN_EVERY_SEC);
       continue;
     }
+
     const profitManagerContract = ProfitManager__factory.connect(GetProfitManagerAddress(), web3Provider);
 
     const creditMultiplier = await profitManagerContract.creditMultiplier();

--- a/src/processors/LoanCaller.ts
+++ b/src/processors/LoanCaller.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { ReadJSON, WaitUntilScheduled, sleep } from '../utils/Utils';
+import { GetProtocolData, ReadJSON, sleep } from '../utils/Utils';
 import path from 'path';
 import { DATA_DIR } from '../utils/Constants';
 import { ethers } from 'ethers';
@@ -15,7 +15,6 @@ async function LoanCaller() {
   while (true) {
     process.title = 'LOAN_CALLER';
     console.log('LoanCaller: starting');
-    const startDate = Date.now();
     const termsFilename = path.join(DATA_DIR, 'terms.json');
     const loansFilename = path.join(DATA_DIR, 'loans.json');
     checks(termsFilename, loansFilename);
@@ -28,15 +27,10 @@ async function LoanCaller() {
       throw new Error('Cannot find RPC_URL in env');
     }
     const web3Provider = new ethers.JsonRpcProvider(rpcURL);
-    const lastBlockTimestamp = (await web3Provider.getBlock(await web3Provider.getBlockNumber()))?.timestamp;
-    if (!lastBlockTimestamp) {
-      await WaitUntilScheduled(startDate, RUN_EVERY_SEC);
-      continue;
-    }
+    // assume lastBlockTimestampMs is date.now() minus 12 sec
+    const lastBlockTimestampMs = Date.now() - 12000;
 
-    const profitManagerContract = ProfitManager__factory.connect(GetProfitManagerAddress(), web3Provider);
-
-    const creditMultiplier = await profitManagerContract.creditMultiplier();
+    const creditMultiplier = GetProtocolData().creditMultiplier;
 
     const loansToCall: { [termAddress: string]: string[] } = {};
 
@@ -50,7 +44,7 @@ async function LoanCaller() {
       }
 
       const termDeprecated = term.status != LendingTermStatus.LIVE;
-      const aboveMaxBorrow = checkAboveMaxBorrow(loan, term, creditMultiplier, lastBlockTimestamp);
+      const aboveMaxBorrow = checkAboveMaxBorrow(loan, term, creditMultiplier, lastBlockTimestampMs);
       const partialRepayDelayPassed = checkPartialRepayDelayPassed(loan, term);
 
       if (termDeprecated || aboveMaxBorrow || partialRepayDelayPassed) {
@@ -89,12 +83,12 @@ async function callMany(loansToCall: { [termAddress: string]: string[] }, web3Pr
   }
 }
 
-function checkAboveMaxBorrow(loan: Loan, term: LendingTerm, creditMultiplier: bigint, lastBlockTimestampSec: number) {
+function checkAboveMaxBorrow(loan: Loan, term: LendingTerm, creditMultiplier: bigint, lastBlockTimestampMs: number) {
   const maxBorrow = (BigInt(loan.collateralAmount) * BigInt(term.maxDebtPerCollateralToken)) / creditMultiplier;
   const interest =
     (BigInt(loan.borrowAmount) *
       BigInt(term.interestRate) *
-      (BigInt(lastBlockTimestampSec * 1000) - BigInt(loan.originationTime))) /
+      (BigInt(lastBlockTimestampMs) - BigInt(loan.originationTime))) /
     BigInt(MS_PER_YEAR) /
     10n ** 18n;
   const openingFee = (BigInt(loan.borrowAmount) * BigInt(term.openingFee)) / 10n ** 18n;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from 'fs';
 import { NodeConfig } from '../model/NodeConfig';
-import { ECG_NODE_CONFIG_FULL_FILENAME, EXPLORER_URI } from './Constants';
+import { DATA_DIR, ECG_NODE_CONFIG_FULL_FILENAME, EXPLORER_URI } from './Constants';
 import fs from 'fs';
+import path from 'path';
+import { ProtocolData, ProtocolDataFileStructure } from '../model/ProtocolData';
 
 export function JsonBigIntReplacer(key: string, value: any) {
   if (typeof value === 'bigint') {
@@ -86,4 +88,17 @@ export async function retry<T extends (...arg0: any[]) => any>(
 export function GetNodeConfig() {
   const nodeConfig: NodeConfig = ReadJSON(ECG_NODE_CONFIG_FULL_FILENAME);
   return nodeConfig;
+}
+
+export function GetProtocolData(): ProtocolData {
+  const protocolDataFilename = path.join(DATA_DIR, 'protocol-data.json');
+
+  const protocolDataFile = ReadJSON(protocolDataFilename) as ProtocolDataFileStructure;
+  console.log(`GetProtocolData: last update ${protocolDataFile.updatedHuman}`);
+
+  if (protocolDataFile.updated < Date.now() - 2 * 3600 * 1000) {
+    throw new Error('Protocol data outdated');
+  } else {
+    return protocolDataFile.data;
+  }
 }

--- a/src/utils/Web3Helper.ts
+++ b/src/utils/Web3Helper.ts
@@ -24,57 +24,6 @@ export async function GetAvgGasPrice(rpcUrl: string) {
   return Math.round(average(results.map((_) => Number(_)))) + 3e9;
 }
 
-/*export async function SignPermit(
-  signer: ethers.Wallet,
-  chainId: number,
-  erc20Name: string,
-  contractAddress: string,
-  spenderAddress: string,
-  amount: string,
-  nonce: string,
-  deadline: number,
-  version = '1'
-) {
-  const types = {
-    Permit: [
-      { name: 'owner', type: 'address' },
-      { name: 'spender', type: 'address' },
-      { name: 'value', type: 'uint256' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'deadline', type: 'uint256' }
-    ]
-  };
-
-  const domainData = {
-    name: erc20Name,
-    version: version ?? '1',
-    chainId: chainId,
-    verifyingContract: contractAddress
-  };
-
-  const message = {
-    owner: signer.address,
-    spender: spenderAddress,
-    value: amount,
-    nonce,
-    deadline
-  };
-
-  const signature = await signer.signTypedData(domainData, types, message);
-
-  const splitSign = ethers.Signature.from(signature);
-  // Append signature and related data to the final array
-  signedRiskDatas.push({
-    r: splitSign.r,
-    s: splitSign.s,
-    v: splitSign.v,
-    liquidationBonus: parameter.bonus,
-    riskData: typedData.value
-  });
-  const [r, s, v] = [slice(signature, 0, 32), slice(signature, 32, 64), slice(signature, 64, 65)];
-  return { r, s, v: hexToNumber(v), deadline: deadline };
-}*/
-
 export async function FetchAllEvents(
   contract: BaseContract,
   contractName: string,
@@ -83,8 +32,7 @@ export async function FetchAllEvents(
   targetBlock: number,
   blockStepLimit?: number
 ): Promise<any[]> {
-  const extractedArray: any[] = new Array();
-  const logPrefix = `fetchAllEvents[${contractName}-${eventName}-all]`;
+  const extractedArray: any[] = [];
 
   const initBlockStep = 100_000;
   //console.log(`${logPrefix}: will fetch events for ${targetBlock - startBlock + 1} blocks`);
@@ -120,7 +68,7 @@ export async function FetchAllEvents(
     if (events.length != 0) {
       for (const e of events) {
         if (e instanceof EventLog) {
-          let obj: any = {
+          const obj: any = {
             transactionHash: e.transactionHash,
             blockHash: e.blockHash,
             blockNumber: e.blockNumber,
@@ -181,7 +129,6 @@ export async function FetchAllEventsAndExtractStringArray(
   blockStepLimit?: number
 ): Promise<string[]> {
   const extractedArray: Set<string> = new Set<string>();
-  const logPrefix = `fetchAllEvents[${contractName}-${eventName}-${argNames.join(',')}]`;
 
   const initBlockStep = 100_000;
   //console.log(`${logPrefix}: will fetch events for ${targetBlock - startBlock + 1} blocks`);


### PR DESCRIPTION
Each time we fetch the ECG data, we now store the creditMultiplier in a protocol-data.json

For now it only contains the creditMultiplier but it might be used to store other data in the future
![image](https://github.com/volt-protocol/ecg-node/assets/9356022/a9398ae3-830c-452e-ae18-1fe40a5748c2)


This allows to use the stored value in 
src/processors/AuctionBidder.ts
and 
src/processors/LoanCaller.ts

instead of calling the RPC to get the latest value of the credit multiplier (which does not change often)
